### PR TITLE
[zephyr] Make Zephyr bazel targets manual

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -30,6 +30,7 @@ cc_library(
         "include",
         "targets/zephyr",
     ],
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 
@@ -61,6 +62,7 @@ alias(
 alias(
     name = "zephyr",
     actual = ":osal_zephyr",
+    tags = ["manual"],
 )
 
 alias(


### PR DESCRIPTION
Mark Zephyr OSAL targets as manual in bazel to avoid failures in wildcard builds.
This is needed because the Zephyr SDK dependency is not auto-loaded as is done for FreeRTOS-runtime.